### PR TITLE
#:PD-25152: Permite ocultar o menu-horizontal e menu-vertical através de variáveis

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betha-plataforma/estrutura-componentes",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Coleção de Web Components para compor a estrutura de uma aplicação front-end da Betha Sistemas.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/components/app/app.scss
+++ b/src/components/app/app.scss
@@ -1,4 +1,5 @@
 @import "../../styles/normalize.scss";
+@import "../../styles/mixins";
 
 .app {
   display: grid;
@@ -22,6 +23,8 @@ slot[name="container_contexto"] {
   align-items: center;
   border-bottom: 1px solid var(--bth-app-gray-light-10);
   margin: 0 16px;
+
+  @include visibilidadeEstrutura();
 }
 
 .banner {
@@ -139,6 +142,8 @@ slot[name="container_contexto"] {
   height: 40px;
   grid-area: menu-horizontal;
   width: 100%;
+
+  @include visibilidadeEstrutura();
 
   &__link--disabled {
     opacity: 0.5;
@@ -271,6 +276,8 @@ slot[name="container_contexto"] {
   border-right: 1px solid var(--bth-app-gray-light-10);
   height: calc(100vh - 40px);
   top: 40px;
+
+  @include visibilidadeEstrutura();
 
   &__body {
     flex: 1;

--- a/src/components/app/app.scss
+++ b/src/components/app/app.scss
@@ -24,7 +24,7 @@ slot[name="container_contexto"] {
   border-bottom: 1px solid var(--bth-app-gray-light-10);
   margin: 0 16px;
 
-  @include visibilidadeEstrutura();
+  @include visibilidadeEstrutura($display: flex);
 }
 
 .banner {
@@ -277,7 +277,7 @@ slot[name="container_contexto"] {
   height: calc(100vh - 40px);
   top: 40px;
 
-  @include visibilidadeEstrutura();
+  @include visibilidadeEstrutura($display: flex);
 
   &__body {
     flex: 1;

--- a/src/index.html
+++ b/src/index.html
@@ -37,6 +37,11 @@
         display: flex;
         align-items: center;
       }
+
+      /*bth-app {*/
+      /*  --bth-app-carta-servicos-display: none;*/
+      /*  --bth-app-carta-servicos-visibility: hidden;*/
+      /*}*/
     </style>
 
   </head>

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -5,7 +5,7 @@
  * "--bth-app-carta-servicos-display" e "--bth-app-carta-servicos-visibility"
  */
 
-@mixin visibilidadeEstrutura() {
-  display: var(--bth-app-carta-servicos-display, inherit);
-  visibility: var(--bth-app-carta-servicos-visibility, inherit);
+@mixin visibilidadeEstrutura($display: unset, $visibility: unset) {
+  display: var(--bth-app-carta-servicos-display, $display);
+  visibility: var(--bth-app-carta-servicos-visibility, $visibility);
 }

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -1,0 +1,11 @@
+
+/**
+ * Carta de Serviços Cidadão Digital
+ * Controla visibilidade do menu-horizontal e menu-vertical através das variáveis
+ * "--bth-app-carta-servicos-display" e "--bth-app-carta-servicos-visibility"
+ */
+
+@mixin visibilidadeEstrutura() {
+  display: var(--bth-app-carta-servicos-display, inherit);
+  visibility: var(--bth-app-carta-servicos-visibility, inherit);
+}


### PR DESCRIPTION
# #:PD-25152: Permite ocultar o menu-horizontal e menu-vertical através de variáveis

Ocultar os menus horizontal e vertical para exibição da estrutura em um iframe

Declarando as variáveis:
```
bth-app {
  --bth-app-carta-servicos-display: none;
  --bth-app-carta-servicos-visibility: hidden;
}
```

## MRs relacionados
- [MR 333 app-conecta #:PD-25152: Carta de Serviços](https://gitlab.services.betha.cloud/ped/plataforma/nopaper/conecta/apps/app-conecta/-/merge_requests/333)