### PR TITLE
Adiciona possibilidade de adicionar headers com menu vertical

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@betha-plataforma/estrutura-componentes",
-  "version": "1.7.2",
+  "version": "1.8.0",
   "description": "Coleção de Web Components para compor a estrutura de uma aplicação front-end da Betha Sistemas.",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -42,6 +42,10 @@ export namespace Components {
          */
         "opcoes"?: Array<OpcaoMenu>;
         /**
+          * Opções de navegação a serem exibidas no header, ao lado da marca. Funciona de forma independente da navegação principal, e somente se o menu for vertical.
+         */
+        "opcoesHeader"?: Array<OpcaoMenu>;
+        /**
           * Define o estado de ativo para o badge no icone do item do menu
           * @param identificador Identificador do menu
           * @param ativo boolean que indica se deve ou não mostrar
@@ -756,6 +760,10 @@ declare namespace LocalJSX {
           * Opções de navegação do menu
          */
         "opcoes"?: Array<OpcaoMenu>;
+        /**
+          * Opções de navegação a serem exibidas no header, ao lado da marca. Funciona de forma independente da navegação principal, e somente se o menu for vertical.
+         */
+        "opcoesHeader"?: Array<OpcaoMenu>;
     }
     interface BthAvatar {
         /**

--- a/src/components/app/app.interfaces.ts
+++ b/src/components/app/app.interfaces.ts
@@ -32,10 +32,10 @@ export interface OpcaoMenu {
   submenus?: Array<OpcaoMenu>;
   possuiPermissao?: boolean;
   possuiBadgeIcone?: boolean;
+  isAtivo?: boolean;
 }
 
 export interface OpcaoMenuInterna extends OpcaoMenu {
-  isAtivo?: boolean;
   isRecolhido?: boolean;
   submenus?: Array<OpcaoMenuInterna>
 }

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -88,6 +88,7 @@ export class App implements ComponentInterface {
   }
 
   @Watch('opcoes')
+  @Watch('opcoesHeader')
   watchOpcoesChanged() {
     // Reseta estado inicial do menu toda vez que opções for alterado, evita reabertura de maneira inconsistente
     this.setEstadoInicialMenu();

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -304,7 +304,6 @@ export class App implements ComponentInterface {
   }
 
   private setEstadoInicialMenu(): void {
-    // this.opcoesMenu = [...this.opcoes];
     this.opcoesMenu = this.validarOpcoes([...this.opcoes]);
     this.opcoesHeaderInternas = this.validarOpcoes([...this.opcoesHeader]);
 

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -620,13 +620,12 @@ export class App implements ComponentInterface {
             )}
 
             {/* Navegação Adicional do Header */}
-            <nav
-              id="menu_header"
-              class="menu-horizontal__item menu-horizontal__item--has-list"
-              aria-label="Navegação do header"
-              aria-hidden={`${!this.possuiOpcoesHeader() || !this.menuVertical}`}>
+            {this.possuiOpcoesHeader() && this.menuVertical && (
+              <nav
+                id="menu_header"
+                class="menu-horizontal__item menu-horizontal__item--has-list"
+                aria-label="Navegação do header">
 
-              {this.possuiOpcoesHeader() && this.menuVertical && (
                 <ul role="menubar" class="menu-horizontal__list" aria-label="Navegação do header">
                   {this.opcoesHeaderInternas.map((opcao, index) => (
                     <li role="none" key={`header_${index}`}>
@@ -642,9 +641,8 @@ export class App implements ComponentInterface {
                     </li>
                   ))}
                 </ul>
-              )}
-            </nav>
-
+              </nav>
+            )}
             {/* Navegação Menu Horizontal */}
             <nav
               id="menu_horizontal_list"

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -304,8 +304,9 @@ export class App implements ComponentInterface {
   }
 
   private setEstadoInicialMenu(): void {
-    this.opcoesMenu = [...this.opcoes];
-    this.opcoesHeaderInternas = [...this.opcoesHeader];
+    // this.opcoesMenu = [...this.opcoes];
+    this.opcoesMenu = this.validarOpcoes([...this.opcoes]);
+    this.opcoesHeaderInternas = this.validarOpcoes([...this.opcoesHeader]);
 
     this.isDispositivoMovel = isDispositivoMovel();
 
@@ -446,6 +447,26 @@ export class App implements ComponentInterface {
       this.isMenuVerticalRecolhido = isMenuVerticalRecolhido;
       this.timeoutAtivoHandler = undefined;
     }, TIMEOUT_INTERACOES);
+  }
+
+  /**
+   * Valida se no máximo um item está ativo e processa o array para o estado interno.
+   * Se múltiplos itens forem passados como 'ativo', TODOS serão desativados como medida de segurança,
+   * e um alerta será exibido no console.
+   * @param opcoes O array de opções de menu a ser processado.
+   * @returns Um novo array de opções com no máximo um item ativo.
+   */
+  private validarOpcoes(opcoes: OpcaoMenu[]): OpcaoMenuInterna[] {
+    if (!opcoes || opcoes.length === 0) {
+      return [];
+    }
+
+    if (opcoes.filter(opt => opt.isAtivo === true).length > 1) {
+      console.warn('[bth-app] Múltiplos itens de menu recebidos como \'ativo\'. Nenhum item foi selecionado.');
+      return opcoes.map(opt => ({ ...opt, isAtivo: false }));
+
+    }
+    return opcoes;
   }
 
   private onMouseOverMenuVertical = (): void => {

--- a/src/components/app/readme.md
+++ b/src/components/app/readme.md
@@ -95,12 +95,13 @@ As opções do menu podem ser configuradas através de algumas propriedades
 
 ## Properties
 
-| Property       | Attribute       | Description                                                                                                             | Type          | Default     |
-| -------------- | --------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------- | ----------- |
-| `banner`       | --              | Permite definir um banner que é exibido acima do menu                                                                   | `Banner`      | `undefined` |
-| `menuBgColor`  | `menu-bg-color` | Permite customizar a cor de fundo da barra do menu. Por padrão segue a cor da linha dos produtos.                       | `string`      | `undefined` |
-| `menuVertical` | `menu-vertical` | Define se as opções do menu serão exibidas no formato "vertical", caso contrário serão exibidas no formato "horizontal" | `boolean`     | `false`     |
-| `opcoes`       | --              | Opções de navegação do menu                                                                                             | `OpcaoMenu[]` | `[]`        |
+| Property       | Attribute       | Description                                                                                                                                                | Type          | Default     |
+| -------------- | --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- | ----------- |
+| `banner`       | --              | Permite definir um banner que é exibido acima do menu                                                                                                      | `Banner`      | `undefined` |
+| `menuBgColor`  | `menu-bg-color` | Permite customizar a cor de fundo da barra do menu. Por padrão segue a cor da linha dos produtos.                                                          | `string`      | `undefined` |
+| `menuVertical` | `menu-vertical` | Define se as opções do menu serão exibidas no formato "vertical", caso contrário serão exibidas no formato "horizontal"                                    | `boolean`     | `false`     |
+| `opcoes`       | --              | Opções de navegação do menu                                                                                                                                | `OpcaoMenu[]` | `[]`        |
+| `opcoesHeader` | --              | Opções de navegação a serem exibidas no header, ao lado da marca. Funciona de forma independente da navegação principal, e somente se o menu for vertical. | `OpcaoMenu[]` | `[]`        |
 
 
 ## Events

--- a/src/components/app/test/app.spec.ts
+++ b/src/components/app/test/app.spec.ts
@@ -180,6 +180,46 @@ describe('app', () => {
     expect(menuVerticalItem.getAttribute('descricao')).toBe(app.opcoes[0].descricao);
   });
 
+  it('renderiza opções de navegação no header quando menu for vertical', async () => {
+    // Arrange
+    await page.setContent('<bth-app menu-vertical></bth-app>');
+
+    // Act
+    const app: HTMLBthAppElement = page.doc.querySelector('bth-app');
+    app.opcoes = [{ id: 1, descricao: 'Opção 1' }];
+    app.opcoesHeader = [{ id: 'relatorios', descricao: 'Relatórios', isAtivo: true }];
+    await page.waitForChanges();
+
+    // Assert
+    const navHeader: HTMLElement = app.shadowRoot.querySelector('#menu_header');
+    expect(navHeader).not.toBeNull();
+    expect(navHeader.getAttribute('aria-hidden')).toBe('false');
+
+    const menuHeaderItem = navHeader.querySelector('bth-menu-horizontal-item');
+    expect(menuHeaderItem).not.toBeNull();
+    expect(menuHeaderItem.getAttribute('identificador')).toBe(app.opcoesHeader[0].id.toString());
+    expect(menuHeaderItem.getAttribute('descricao')).toBe(app.opcoesHeader[0].descricao);
+    expect(menuHeaderItem.getAttribute('ativo')).not.toBeNull();
+  });
+
+  it('não renderiza opções de navegação no header quando menu for horizontal', async () => {
+    // Arrange
+    await page.setContent('<bth-app></bth-app>'); // Sem 'menu-vertical'
+
+    // Act
+    const app: HTMLBthAppElement = page.doc.querySelector('bth-app');
+    app.opcoesHeader = [{ id: 'relatorios', descricao: 'Relatórios' }];
+    await page.waitForChanges();
+
+    // Assert
+    const navHeader: HTMLElement = app.shadowRoot.querySelector('#menu_header');
+    expect(navHeader).not.toBeNull();
+    expect(navHeader.getAttribute('aria-hidden')).toBe('true');
+
+    const menuHeaderItem = navHeader.querySelector('bth-menu-horizontal-item');
+    expect(menuHeaderItem).toBeNull();
+  });
+
   it('renderiza banner', async () => {
     // Arrange
     await page.setContent('<bth-app menu-vertical></bth-app>');

--- a/src/components/app/test/app.spec.ts
+++ b/src/components/app/test/app.spec.ts
@@ -193,7 +193,6 @@ describe('app', () => {
     // Assert
     const navHeader: HTMLElement = app.shadowRoot.querySelector('#menu_header');
     expect(navHeader).not.toBeNull();
-    expect(navHeader.getAttribute('aria-hidden')).toBe('false');
 
     const menuHeaderItem = navHeader.querySelector('bth-menu-horizontal-item');
     expect(menuHeaderItem).not.toBeNull();
@@ -213,11 +212,7 @@ describe('app', () => {
 
     // Assert
     const navHeader: HTMLElement = app.shadowRoot.querySelector('#menu_header');
-    expect(navHeader).not.toBeNull();
-    expect(navHeader.getAttribute('aria-hidden')).toBe('true');
-
-    const menuHeaderItem = navHeader.querySelector('bth-menu-horizontal-item');
-    expect(menuHeaderItem).toBeNull();
+    expect(navHeader).toBeNull();
   });
 
   it('renderiza banner', async () => {

--- a/src/index.html
+++ b/src/index.html
@@ -202,6 +202,13 @@
         },
       ];
 
+      app.opcoesHeader = [
+        { id: 'relatorios', descricao: 'Relatórios', rota: '' },
+        { id: 'script', descricao: 'Scripts', rota: '' },
+        { id: 'campo', descricao: 'Campo', rota: '' },
+        { id: 'bpm', descricao: 'BPM', rota: '', isAtivo: true }
+      ];
+
       var banner = {
         texto: 'Sua conexão com a internet está instável. Por isso, o sistema pode apresentar lentidão e prejudicar algumas atividades',
         tipo: 'warning',


### PR DESCRIPTION
# Adiciona possibilidade de adicionar headers com menu vertical

## Descrição
Foi adicionado a possibilidade de adicionar itens no menu horizontal, mantendo o menu vertical, caso a configuração do menu principal seja **vertical**.

Foi adicionado uma nova propriedade `opcoesHeader`, que serve para adicionar tais configurações.

Alem disso, foi alterado para que seja possível já enviar opções ativadas.

## Tipo de Mudança

- [ ] Correção de bug (correção de um problema)
- [X] Nova funcionalidade (mudança que adiciona uma nova funcionalidade)
- [ ] Refatoração de código (melhoria de código que não altera a funcionalidade existente)
- [ ] Documentação (alteração ou adição de documentação)
- [ ] Outros (especifique)

## Tickets Relacionados
:#EX-7849

## Capturas de Tela
<img width="815" height="497" alt="image" src="https://github.com/user-attachments/assets/14f4918b-1789-497f-86e2-ea2daa959836" />


## Checklist

- [X] Realizei uma revisão do meu próprio código
- [X] Comentei meu código, especialmente em áreas difíceis de entender
- [ ] Atualizei a documentação relevante
- [X] Incluí novos testes ou atualizei os testes existentes
- [X] Todos os testes novos e existentes passaram